### PR TITLE
replace deprecated RED.events nodes-started with flows:started

### DIFF
--- a/actionflows/actionflows.js
+++ b/actionflows/actionflows.js
@@ -612,5 +612,5 @@ module.exports = function(RED) {
     return {};
   }
 
-  RED.events.on("nodes-started", runtimeMap);
+  RED.events.on("flows:started", runtimeMap);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-actionflows",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Create extendable, loopable, and reusable design patterns for flows.",
   "author": "Stephen J. Carnam <steveorevo@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Update code to address error message: `[warn] [RED.events] Deprecated use of "nodes-started" event` and bump version to 2.0.4.